### PR TITLE
Add ERB parsing to YAML configuration

### DIFF
--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -1,4 +1,5 @@
 require 'yaml'
+require 'erb'
 
 module Logger
   def Logger.get_path
@@ -19,7 +20,9 @@ module ConfigFile
 
   def ConfigFile.read
     path = get_path
-    data = YAML.load(File.read(path)) if File.exists?(path)
+    raw_data = IO.read path
+    erbified_data = ERB.new(raw_data).result
+    data = YAML.load(erbified_data) if File.exists?(path)
     data = !data ? {} : data
   end
 end
@@ -57,7 +60,9 @@ module PullRequestsData
 
   def PullRequestsData.read
     path = get_path
-    data = YAML.load(File.read(path)) if File.exists?(path)
+    raw_data = IO.read path
+    erbified_data = ERB.new(raw_data).result
+    data = YAML.load(erbified_data) if File.exists?(path)
     data = !data ? {} : data
   end
 


### PR DESCRIPTION
This allows you to insert shell configuration or other Ruby code in ERb tags in your YAML configuration. This promotes further forking and development on the project, as Jently currently required you to clone and/or fork the repo to insert your sensitive config, which should almost never be included in a Git repo.

eLocal keeps its sensitive configuration in shell environment variables, but we don't believe we need to enforce our conventions over anyone else. As long as the shell vars are set, and you specify them in the YAML, they should be used in place of the values of each attribute.
