### PR TITLE
Pull from GitHub's provided merge ref.

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -44,13 +44,8 @@ module Git
     Logger.log("Deleting remote testing branch - status: #{status} - stdout: #{stdout} - stderr: #{stderr}")
   end
 
-  # Assume a pull request that wants to merge sha_A of branch_A into sha_B of branch_B.
-  # The git commands can then be explained as:
-  # - checkout sha_A. if sha_A is not the head of branch_A, then you'll end up in a headless state.
-  # - make a new branch by branching of sha_A. This will give you a new branch irregardless of the state you were in before.
-  # - merge sha_b into this newly created branch.
-  # Your branch now contains the same code as would have been created by merging the pull request.
-  # We can now run our tests on this branch in order to determine whether merging the pull request will break any tests.
+  # Fetch the code that would result from merging this pull request straight from Github.
+  # The branch containing this code will now be available locally as FETCH_HEAD.
   def Git.create_testing_branch(pull_request)
     config = ConfigFile.read
     repository_path = Repository.get_path
@@ -58,9 +53,9 @@ module Git
       cd #{repository_path} &&
       git reset --hard &&
       git clean -df &&
-      git fetch --all &&
+      git fetch origin refs/pull/#{pull_request[:id]}/merge &&
+      git checkout FETCH_HEAD &&
       git checkout -b #{config[:testing_branch_name]} &&
-      git pull origin refs/pull/#{pull_request[:id]}/merge &&
       git push origin #{config[:testing_branch_name]}
     GIT
     status, stdout, stderr = systemu(cmd)

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -87,8 +87,8 @@ describe Git do
       Git.create_testing_branch(pull_request)
     end
 
-    it 'pulls the merged reference of the pull request' do
-      Git.should_receive(:systemu).with(/git pull origin #{merge_ref}/m).and_return(system_results)
+    it 'fetches the merged reference of the pull request' do
+      Git.should_receive(:systemu).with(/git fetch origin #{merge_ref}/m).and_return(system_results)
 
       Git.create_testing_branch(pull_request)
     end


### PR DESCRIPTION
As mentioned in a [previous discussion](https://github.com/vaneyckt/Jently/issues/2#issuecomment-12800074), GitHub provides a merged version of the pull request. Since we only test when the request can be merged without conflict, it's safe to use this reference instead.

In our case, developers make pull requests from their private fork of the main repo and the Jently user does not always have access to the fork, so checkout fails. Using the merged GitHub reference gets around this.
