### PR TITLE
modify code and add tests

### DIFF
--- a/lib/github.rb
+++ b/lib/github.rb
@@ -32,9 +32,8 @@ module Github
 
       # Sort statuses elements in order of updated_at date, and pull out the
       # state fields.
-      status_states = status.sort_by {|s| status.updated_at }.map {|s| s.state }
-
-      data[:status] = status_states.first || 'undefined'
+      sorted_statuses = statuses.sort_by { |s| s.updated_at }.map { |s| s.state }
+      data[:status] = sorted_statuses.last || 'undefined'
 
       # Update base_sha separately. The pull_request call is
       # not guaranteed to return the last sha of the base branch.

--- a/spec/github_spec.rb
+++ b/spec/github_spec.rb
@@ -135,9 +135,9 @@ describe Github do
       end
 
       context 'when there are statuses for the current head commit' do
-        it 'returns a hash with status attribute set to the state of the last status' do
-          status_1 = mock('CommitStatus', :state => 'amazing')
-          status_2 = mock('CommitStatus', :state => 'terrible')
+        it 'returns a hash with status attribute set to the state of the most recent status' do
+          status_1 = mock('CommitStatus', :state => 'amazing', :updated_at => '2013-10-02 03:11:57 UTC' )
+          status_2 = mock('CommitStatus', :state => 'terrible', :updated_at => '2013-10-02 03:11:58 UTC')
           octokit_client.stub(:statuses).and_return([status_1, status_2])
 
           result = Github.get_pull_request(pull_request_id)
@@ -412,9 +412,9 @@ describe Github do
       end
 
       context 'when there are statuses for the current head commit' do
-        it 'returns a hash with status attribute set to the state of the last status' do
-          status_1 = mock('CommitStatus', :state => 'amazing')
-          status_2 = mock('CommitStatus', :state => 'terrible')
+        it 'returns a hash with status attribute set to the state of the most recent status' do
+          status_1 = mock('CommitStatus', :state => 'amazing', :updated_at => '2013-10-02 03:11:57 UTC' )
+          status_2 = mock('CommitStatus', :state => 'terrible', :updated_at => '2013-10-02 03:11:58 UTC')
           octokit_client.stub(:statuses).and_return([status_1, status_2])
 
           result = Github.get_pull_request(pull_request_id)


### PR DESCRIPTION
allow github to return statuses in an unsorted order
