### PR TITLE
Make the sample config an explicit sample.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ jently.pid
 .ruby-version
 .ruby-gemset
 db/*
+config/*
 repositories/*

--- a/config/sample-config.yaml.erb
+++ b/config/sample-config.yaml.erb
@@ -1,4 +1,10 @@
 ---
+#
+# This is a SAMPLE configuration file. If you wish to use it, copy it to
+# "config/config.yaml.erb" and remove this notice.
+#
+
+
 # The account that Jently will use for communicating with GitHub.
 # You can either use standard login credentials, or you can
 # specify a GitHub oauth token. If you choose to use an oauth token,


### PR DESCRIPTION
Allows you to have config/config.yaml.erb without it easily accidentally getting into Git when you make commits to Jently source.
